### PR TITLE
New read_first_record method and minor documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # MetopDatasets.jl
-[![documentation stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://eumetsat.github.io/MetopDatasets.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://eumetsat.github.io/MetopDatasets.jl/dev/)
 [![Build Status](https://github.com/eumetsat/MetopDatasets.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/eumetsat/MetopDatasets.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)

--- a/docs/src/IASI.md
+++ b/docs/src/IASI.md
@@ -1,7 +1,7 @@
 ## IASI
 
 The Infrared Atmospheric Sounding Interferometer (IASI) is an instrument on the METOP satellites. It is a hyper-spectral sensor measuring the radiation from the atmosphere and earth in 8461 spectral channels. These measurements are used to derive used to derive a plethora of geophysical variables (e.g. temperature and humidity profiles). This makes IASI a key data source for numerical weather prediction (NWP) and applications in atmospheric chemistry and monitoring of essential climate variables.
-See [ASI Level 1: Product Guide](https://user.eumetsat.int/s3/eup-strapi-media/pdf_iasi_pg_487c765315.pdf) and [IASI Level 2: Product Guide](https://user.eumetsat.int/s3/eup-strapi-media/IASI_Level_2_Product_Guide_8f61a2369f.pdf) for more information.
+See [IASI Level 1: Product Guide](https://user.eumetsat.int/s3/eup-strapi-media/pdf_iasi_pg_487c765315.pdf) and [IASI Level 2: Product Guide](https://user.eumetsat.int/s3/eup-strapi-media/IASI_Level_2_Product_Guide_8f61a2369f.pdf) for more information.
 
 
 ## Static plot of L1C spectra

--- a/src/InterfaceDataModel/Dataset.jl
+++ b/src/InterfaceDataModel/Dataset.jl
@@ -138,6 +138,8 @@ Base.close(ds::MetopDataset) = close(ds.file_pointer)
 
 """
     read_first_record(ds::MetopDataset, record_type::Type{<:Record})
+    read_first_record(file_pointer::IO, record_type::Type{<:Record})
+    read_first_record(file_path::AbstractString, record_type::Type{<:Record})
 
 Read the first record of type `record_type` from the dataset. This can be used to access records that are 
 not directly exposed through the `MetopDataset` interface.

--- a/src/genericFunctions/read_first_record.jl
+++ b/src/genericFunctions/read_first_record.jl
@@ -33,3 +33,10 @@ function read_first_record(file_pointer::IO, record_type::Type{<:Record})
     seek(file_pointer, record_offset)
     return native_read(file_pointer, record_type)
 end
+
+function read_first_record(file_path::AbstractString, record_type::Type{<:Record})
+    record = open(file_path) do file_pointer
+        return read_first_record(file_pointer, record_type)
+    end
+    return record
+end

--- a/test/Dataset.jl
+++ b/test/Dataset.jl
@@ -105,5 +105,10 @@ end
     @test ipr isa MetopDatasets.InternalPointerRecord
     mdr = MetopDatasets.read_first_record(ds, MetopDatasets.ASCA_SZR_1B_V13)
     @test mdr isa MetopDatasets.ASCA_SZR_1B_V13
+
+    # read directly from file
+    mphr2 = MetopDatasets.read_first_record(test_file, MetopDatasets.MainProductHeader)
+    @test mphr2 isa MetopDatasets.MainProductHeader
+
     close(ds)
 end


### PR DESCRIPTION
I wanted to add historic IASI L1C formats but this was not needed. The current IASI L1C format is the same formats as the oldest files on the data store (2013).  The format has been the same since 2010 so that is good enough. 

I will just add the historic formats if someone request it.

Other changes made instead.
- Fix typo in documentation
- Remove stable documentation link in readme. We can added it again when we actually have a working link
- Add method to `read_first_record` for file path.
